### PR TITLE
slug fails when property not found in special pages + add option for lowercasing slug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,20 @@ function matchGlobArray (file, patterns) {
   });
 }
 
+function save(files, file, property, slugOpts, rename) {
+  var rename = rename || false;
+  var currFile = files[file];
+
+  if (currFile[property] === undefined) return;
+
+  if (rename) {
+    saveSlug(files, file, property, slugOpts);
+    renameKey(files, file);
+  } else {
+    saveSlug(files, file, property, slugOpts);
+  }
+}
+
 function saveSlug (files, file, property, slugOpts) {
   var currFile = files[file];
   currFile.slug = slug(currFile[property], slugOpts);
@@ -21,7 +35,10 @@ function renameKey (files, file) {
   var currExt = path.extname(file);
   var slugFilename = path.join(currPath, currFile.slug + currExt);
 
+  if (slugFilename === file) return;
+
   files[slugFilename] = currFile;
+
   delete files[file];
 }
 
@@ -31,6 +48,7 @@ function plugin (opts) {
   opts.renameFiles = opts.renameFiles || false;
 
   var slugOpts = {};
+
   Object.keys(slug.defaults).forEach(function (slugOpt) {
     slugOpts[slugOpt] = opts[slugOpt] || slug.defaults[slugOpt];
   });
@@ -43,18 +61,10 @@ function plugin (opts) {
       return matchGlobArray(file, opts.patterns);
     });
 
-    if (opts.renameFiles) {
-      matchedFiles.forEach(function (file) {
-        saveSlug(files, file, opts.property, slugOpts);
-        renameKey(files, file);
-      });
-    } else {
-      matchedFiles.forEach(function (file) {
-        saveSlug(files, file, opts.property, slugOpts);
-      });
-    }
+    matchedFiles.forEach(function (file) {
+      save(files, file, opts.property, slugOpts, opts.renameFiles);
+    });
 
     done();
   };
 }
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,23 +10,29 @@ function matchGlobArray (file, patterns) {
   });
 }
 
-function save(files, file, property, slugOpts, rename) {
+function save(files, file, property, slugOpts, rename, lowercase) {
   var rename = rename || false;
   var currFile = files[file];
 
   if (currFile[property] === undefined) return;
 
   if (rename) {
-    saveSlug(files, file, property, slugOpts);
+    saveSlug(files, file, property, slugOpts, lowercase);
     renameKey(files, file);
   } else {
-    saveSlug(files, file, property, slugOpts);
+    saveSlug(files, file, property, slugOpts, lowercase);
   }
 }
 
-function saveSlug (files, file, property, slugOpts) {
+function saveSlug (files, file, property, slugOpts, lowercase) {
   var currFile = files[file];
-  currFile.slug = slug(currFile[property], slugOpts);
+  var newSlug = slug(currFile[property], slugOpts);
+
+  if (lowercase) {
+    newSlug = newSlug.toLowerCase();
+  }
+
+  currFile.slug = newSlug;
 }
 
 function renameKey (files, file) {
@@ -46,6 +52,7 @@ function plugin (opts) {
   opts = opts || {};
   opts.property = opts.property || 'title';
   opts.renameFiles = opts.renameFiles || false;
+  opts.lowercase = opts.lowercase || false;
 
   var slugOpts = {};
 
@@ -62,7 +69,7 @@ function plugin (opts) {
     });
 
     matchedFiles.forEach(function (file) {
-      save(files, file, opts.property, slugOpts, opts.renameFiles);
+      save(files, file, opts.property, slugOpts, opts.renameFiles, opts.lowercase);
     });
 
     done();


### PR DESCRIPTION
I have at least 2 scenarios where property is not defined and therefore causes slug to fail:

1. An index.md file which redirects from / -> /blog
2. Listing page

These source files are like below:

```
---                                                                                                                                        │
template: index.jade                                                                                                                       │
---
```

So I made 2 changes:

1. Created a wrapper method which takes renaming as parameter and terminates if property not defined
2. Terminates renaming when input filename equals to output filename (it deletes the file if not terminated)

Hope you'll find these changes appropriate. Thanks for the plugin!