### PR TITLE
Update dependencies and various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # metalsmith slug
 
-Add a slug property to the metadata for targeted files in your
+Add a `slug` property to the metadata for targeted files in your
 [Metalsmith](http://www.metalsmith.io/), based on a particular property.
-Useful for generating links to pages based on, say, their title.
+Useful for generating links to pages based on, say, their `title`.
 
 ## Installation
 
-    npm install metalsmith-slug
+    npm install metalsmith-slug --save
 
 ## Usage
 
-If you're not familiar with Metalsmith, check it out. It's a versatile file
-processor that can be used for static site generation, project scaffolding and
-more. It can be interacted with via a CLI or JavaScript API.
+If you're not familiar with Metalsmith, [check it out](http://metalsmith.io). It's a versatile file processor that can be used for static site generation,
+project scaffolding and more. It can be interacted with via a CLI or
+JavaScript API.
 
 ### Metalsmith CLI
 
@@ -38,25 +38,25 @@ metalsmith.use(slug());
 
 ## Options
 
-**patterns** _[array]_: Glob patterns of files to match. Uses
-[minimatch](https://github.com/isaacs/minimatch).
+**patterns** `Array`: Glob patterns of files to match. Uses
+[minimatch](https://github.com/isaacs/minimatch). Default: `[]`.
 
 ```js
 metalsmith.use(slug({
-  patterns: ['*.md', '*.rst'] // Deafults to metalsmith.source() directory
+  patterns: ['*.md', '*.rst'] // Deafults to all files
 }));
 ```
 
-**property** _'string'_: Property to generate the slug from.
+**property** `String`: Property to generate the slug from. Default: `title`.
 
 ```js
 metalsmith.use(slug({
-  property: 'name' // Defaults to 'title'
+  property: 'name'
 }));
 ```
 
-**renameFiles** _boolean_: When set to `true`, will rename the files passed to
-metalsmith-slug to the file's new slug property.
+**renameFiles** `Boolean`: When set to `true`, will rename the files passed to
+metalsmith-slug to the file's new slug property. Default: `false`.
 
 ```js
 metalsmith.use(slug({
@@ -64,12 +64,25 @@ metalsmith.use(slug({
 }));
 ```
 
-**slug options**: You can additionally use any of the options available to [node-slug](https://github.com/dodo/node-slug#options)
+**slug options**: You can additionally use any of the options available for [node-slug](https://github.com/dodo/node-slug#options).
 
 ```js
+// This are the defaults for node-slug 'pretty' mode
 metalsmith.use(slug({
-  replacement: '_', // Defaults to node-slug defaults
-  symbols: false
+  replacement: '-',
+  symbols: true,
+  remove: /[.]/g,
+  lower: false,
+  charmap: [object Object], // slug.defaults.charmap
+  multicharmap: [object Object], // slug.defaults.multicharmap
+}));
+```
+
+Alternatively you can change the default node-slug mode:
+
+```
+metalsmith.use(slug({
+  mode: 'rfc3986'
 }));
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,8 +47,7 @@ function plugin (opts) {
   });
 
   return function (files, metalsmith, done) {
-    var src = metalsmith.source();
-    opts.patterns = opts.patterns || [src + '/**'];
+    opts.patterns = opts.patterns || ['**'];
 
     var matchedFiles = Object.keys(files).filter(function (file) {
       return matchGlobArray(file, opts.patterns);

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ module.exports = plugin;
 
 function matchGlobArray (file, patterns) {
   return patterns.some(function (pattern) {
-    return minimatch(file, pattern, { matchBase: true});
+    return minimatch(file, pattern, { matchBase: true });
   });
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,10 +16,6 @@ function saveSlug (files, file, opts, slugOpts) {
 
   var newSlug = slug(currFile[opts.property], slugOpts);
 
-  if (opts.lowercase) {
-    newSlug = newSlug.toLowerCase();
-  }
-
   if (opts.renameFiles) {
     var currPath = path.dirname(file);
     var currExt = path.extname(file);
@@ -35,15 +31,19 @@ function saveSlug (files, file, opts, slugOpts) {
 }
 
 function plugin (opts) {
+  // Plugin options
   opts = opts || {};
+  opts.lower = opts.lower || opts.lowercase; // 'lowercase' for backward compatibility
+  opts.mode = opts.mode || slug.defaults.mode;
   opts.property = opts.property || 'title';
   opts.renameFiles = opts.renameFiles || false;
-  opts.lowercase = opts.lowercase || false;
 
-  var slugOpts = {};
+  // Slug options
+  var slugOpts     = {};
+  var slugDefaults = slug.defaults.modes[opts.mode];
 
-  Object.keys(slug.defaults).forEach(function (slugOpt) {
-    slugOpts[slugOpt] = opts[slugOpt] || slug.defaults[slugOpt];
+  Object.keys(slugDefaults).forEach(function (slugOpt) {
+    slugOpts[slugOpt] = opts[slugOpt] || slugDefaults[slugOpt];
   });
 
   return function (files, metalsmith, done) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,20 +14,18 @@ function saveSlug (files, file, opts, slugOpts) {
   var currFile = files[file];
   if (currFile[opts.property] === undefined) return;
 
-  var newSlug = slug(currFile[opts.property], slugOpts);
+  currFile.slug = slug(currFile[opts.property], slugOpts);
 
   if (opts.renameFiles) {
     var currPath = path.dirname(file);
     var currExt = path.extname(file);
     var slugFilename = path.join(currPath, currFile.slug + currExt);
 
-    if (slugFilename === file) return;
-
-    files[slugFilename] = currFile;
-    delete files[file];
+    if (slugFilename !== file) {
+      files[slugFilename] = currFile;
+      delete files[file];
+    }
   }
-
-  currFile.slug = newSlug;
 }
 
 function plugin (opts) {

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   },
   "homepage": "https://github.com/nsonnad/metalsmith-slug",
   "dependencies": {
-    "minimatch": "^0.3.0",
-    "slug": "^0.5.0"
+    "minimatch": "2.x",
+    "slug": "0.9.x"
   },
   "devDependencies": {
-    "metalsmith": "^0.10.0",
+    "metalsmith": "1.x",
     "tap": "^0.4.12",
     "tap-dot": "^0.2.3"
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "metalsmith": "1.x",
-    "tap": "^0.4.12",
-    "tap-dot": "^0.2.3"
+    "tap": "^1.3.1",
+    "tap-dot": "^1.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,20 @@ test('it should match the given patterns', function (t) {
     .build(testDone(t));
 });
 
+test('it should rename the files', function (t) {
+  t.plan(4);
+
+  Metalsmith('test/fixtures/basic')
+    .use(metalsmithSlug({ renameFiles: true }))
+    .use(testFiles(t, {
+      'test-noproperty.md': undefined,
+      'A-simple-string-of-characters.md': 'A-simple-string-of-characters',
+      'ccoeOEsumrdftmooadeltainfinityloveandorlessgreater.md': 'ccoeOEsumrdftmooadeltainfinityloveandorlessgreater',
+      'radioactiveskull-and-bonescaduceusbiohazardhammer-and-sickleyin-yangpeacetelephoneumbrella-with-rain-dropstelephone-sun-with-raysstarumbrellasnowmanairplaneenveloperaised-fist.md': 'radioactiveskull-and-bonescaduceusbiohazardhammer-and-sickleyin-yangpeacetelephoneumbrella-with-rain-dropstelephone-sun-with-raysstarumbrellasnowmanairplaneenveloperaised-fist',
+    }))
+    .build(testDone(t));
+});
+
 test('it should work with "lowercase" option (backward compatibility)', function (t) {
   t.plan(4);
 

--- a/test/index.js
+++ b/test/index.js
@@ -4,8 +4,6 @@ var metalsmithSlug = require('..');
 var slug           = require('slug');
 
 test('it should work with default options', function (t) {
-  t.plan(4);
-
   Metalsmith('test/fixtures/basic')
     .use(metalsmithSlug())
     .use(testFiles(t, {
@@ -18,8 +16,6 @@ test('it should work with default options', function (t) {
 });
 
 test('it should sluggify the specified property', function (t) {
-  t.plan(4);
-
   Metalsmith('test/fixtures/basic')
     .use(function (files, ms, done) {
       for (var file in files) {
@@ -41,8 +37,6 @@ test('it should sluggify the specified property', function (t) {
 });
 
 test('it should match the given patterns', function (t) {
-  t.plan(4);
-
   Metalsmith('test/fixtures/basic')
     .use(metalsmithSlug({
       patterns: ['test-s*.md']
@@ -57,8 +51,6 @@ test('it should match the given patterns', function (t) {
 });
 
 test('it should rename the files', function (t) {
-  t.plan(4);
-
   Metalsmith('test/fixtures/basic')
     .use(metalsmithSlug({ renameFiles: true }))
     .use(testFiles(t, {
@@ -71,8 +63,6 @@ test('it should rename the files', function (t) {
 });
 
 test('it should work with "lowercase" option (backward compatibility)', function (t) {
-  t.plan(4);
-
   Metalsmith('test/fixtures/basic')
     .use(metalsmithSlug({ lowercase: true }))
     .use(testFiles(t, {
@@ -85,8 +75,6 @@ test('it should work with "lowercase" option (backward compatibility)', function
 });
 
 test('it should take slug options', function (t) {
-  t.plan(4);
-
   Metalsmith('test/fixtures/basic')
     .use(metalsmithSlug({ lower: true }))
     .use(testFiles(t, {
@@ -99,8 +87,6 @@ test('it should take slug options', function (t) {
 });
 
 test('it should change the slug mode', function (t) {
-  t.plan(4);
-
   Metalsmith('test/fixtures/basic')
     .use(metalsmithSlug({ mode: 'rfc3986' }))
     .use(testFiles(t, {

--- a/test/index.js
+++ b/test/index.js
@@ -3,33 +3,118 @@ var Metalsmith     = require('metalsmith');
 var metalsmithSlug = require('..');
 var slug           = require('slug');
 
-var testProperty = 'title';
-
-test('it should specified property of metalsmith files to a slug', function (t) {
+test('it should work with default options', function (t) {
   t.plan(4);
 
-  var metalsmith = Metalsmith('test/fixtures/basic');
-
-  metalsmith
-    .use(metalsmithSlug({
-      patterns: ['*.md'],
-      property: testProperty
+  Metalsmith('test/fixtures/basic')
+    .use(metalsmithSlug())
+    .use(testFiles(t, {
+      'test-noproperty.md': undefined,
+      'test-simple.md':     'A-simple-string-of-characters',
+      'test-symbols.md':    'ccoeOEsumrdftmooadeltainfinityloveandorlessgreater',
+      'test-unicode.md':    'radioactiveskull-and-bonescaduceusbiohazardhammer-and-sickleyin-yangpeacetelephoneumbrella-with-rain-dropstelephone-sun-with-raysstarumbrellasnowmanairplaneenveloperaised-fist',
     }))
-    .build(function (err, files) {
-      if (err) {
-        console.error(err); t.end();
-      }
-
-      Object.keys(files).forEach(function (file) {
-        var currFile = files[file];
-        if (currFile[testProperty]) {
-          t.equal(currFile.slug, slug(currFile.title), currFile.testName);
-        } else {
-          t.equal(currFile.slug, undefined, currFile.testName);
-        }
-      });
-
-      t.end();
-    });
+    .build(testDone(t));
 });
 
+test('it should sluggify the specified property', function (t) {
+  t.plan(4);
+
+  Metalsmith('test/fixtures/basic')
+    .use(function (files, ms, done) {
+      for (var file in files) {
+        files[file].name = files[file].title;
+      }
+
+      done();
+    })
+    .use(metalsmithSlug({
+      property: 'name'
+    }))
+    .use(testFiles(t, {
+      'test-noproperty.md': undefined,
+      'test-simple.md':     'A-simple-string-of-characters',
+      'test-symbols.md':    'ccoeOEsumrdftmooadeltainfinityloveandorlessgreater',
+      'test-unicode.md':    'radioactiveskull-and-bonescaduceusbiohazardhammer-and-sickleyin-yangpeacetelephoneumbrella-with-rain-dropstelephone-sun-with-raysstarumbrellasnowmanairplaneenveloperaised-fist',
+    }))
+    .build(testDone(t));
+});
+
+test('it should match the given patterns', function (t) {
+  t.plan(4);
+
+  Metalsmith('test/fixtures/basic')
+    .use(metalsmithSlug({
+      patterns: ['test-s*.md']
+    }))
+    .use(testFiles(t, {
+      'test-noproperty.md': undefined,
+      'test-simple.md':     'A-simple-string-of-characters',
+      'test-symbols.md':    'ccoeOEsumrdftmooadeltainfinityloveandorlessgreater',
+      'test-unicode.md':    undefined,
+    }))
+    .build(testDone(t));
+});
+
+test('it should work with "lowercase" option (backward compatibility)', function (t) {
+  t.plan(4);
+
+  Metalsmith('test/fixtures/basic')
+    .use(metalsmithSlug({ lowercase: true }))
+    .use(testFiles(t, {
+      'test-noproperty.md': undefined,
+      'test-simple.md':     'a-simple-string-of-characters',
+      'test-symbols.md':    'ccoeoesumrdftmooadeltainfinityloveandorlessgreater',
+      'test-unicode.md':    'radioactiveskull-and-bonescaduceusbiohazardhammer-and-sickleyin-yangpeacetelephoneumbrella-with-rain-dropstelephone-sun-with-raysstarumbrellasnowmanairplaneenveloperaised-fist',
+    }))
+    .build(testDone(t));
+});
+
+test('it should take slug options', function (t) {
+  t.plan(4);
+
+  Metalsmith('test/fixtures/basic')
+    .use(metalsmithSlug({ lower: true }))
+    .use(testFiles(t, {
+      'test-noproperty.md': undefined,
+      'test-simple.md':     'a-simple-string-of-characters',
+      'test-symbols.md':    'ccoeoesumrdftmooadeltainfinityloveandorlessgreater',
+      'test-unicode.md':    'radioactiveskull-and-bonescaduceusbiohazardhammer-and-sickleyin-yangpeacetelephoneumbrella-with-rain-dropstelephone-sun-with-raysstarumbrellasnowmanairplaneenveloperaised-fist',
+    }))
+    .build(testDone(t));
+});
+
+test('it should change the slug mode', function (t) {
+  t.plan(4);
+
+  Metalsmith('test/fixtures/basic')
+    .use(metalsmithSlug({ mode: 'rfc3986' }))
+    .use(testFiles(t, {
+      'test-noproperty.md': undefined,
+      'test-simple.md':     'a-simple-string-of-characters',
+      'test-symbols.md':    'ccoeoesumrdftm...ooadeltainfinityloveandorlessgreater',
+      'test-unicode.md':    'radioactiveskull-and-bonescaduceusbiohazardhammer-and-sickleyin-yangpeacetelephoneumbrella-with-rain-dropstelephone-sun-with-raysstarumbrellasnowmanairplaneenveloperaised-fist',
+    }))
+    .build(testDone(t));
+});
+
+function testFiles(t, tests) {
+  return function (files, ms, done) {
+    Object.keys(files).forEach(function (file) {
+      var currFile = files[file];
+
+      if (file in tests) {
+        t.equal(currFile.slug, tests[file], currFile.testName);
+      }
+    });
+
+    done();
+  };
+}
+
+function testDone(t) {
+  return function (err) {
+    if (err) { console.error(err); }
+    t.end();
+  };
+}


### PR DESCRIPTION
Hi, I've made some changes to update it to the latest Metalsmith + dependencies. Summary:

- Update `node-slug` & `minimatch`
- Tests with Metalsmith `1.x`
- Improved test coverage
- Better integration with `node-slug`. `lowercase` option removed in favor of `node-slug`s `lower`. `lowercase` should still work for backward compatibility.
- Fixed `renameFiles` option
- Fixed #4 
- Updated README

Merge, and pump version to `0.7.0`? :smile: 