### PR TITLE
undefined filenames fixed when renameFiles is true

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ function saveSlug (files, file, opts, slugOpts) {
   if (opts.renameFiles) {
     var currPath = path.dirname(file);
     var currExt = path.extname(file);
-    var slugFilename = path.join(currPath, currFile.slug + currExt);
+    var slugFilename = path.join(currPath, newSlug + currExt);
 
     if (slugFilename === file) return;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-slug",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "slugify a property in metalsmith",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
slug attribute is being added to the file object at the end of saveSlug function. therefore it renames files as "undefined...".